### PR TITLE
Update to channels v1.0.0-beta.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "typing-extensions >= 4.5.0, < 5",
   "grpcio >= 1.54.2, < 2",
   "grpcio-tools >= 1.54.2, < 2",
-  "frequenz-channels >= 0.16.0, < 0.17.0",
+  "frequenz-channels >= v1.0.0-beta.2, < 2",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Not using the latest one (beta.2) to not force downstream projects that are
using .1 to update.
