### PR TITLE
Downgrade minimum `protobuf` to 4.21.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ requires-python = ">= 3.11, < 4"
 dependencies = [
   "frequenz-channels >= v1.0.0-beta.2, < 2",
   "grpcio >= 1.54.2, < 2",
-  "protobuf >= 4.25.3, < 5",
+  "protobuf >= 4.21.6, < 5",
   "typing-extensions >= 4.5.0, < 5",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
This version should work too, as it is what we use in the SDK as minimum version. Since we are testing that the minimum requirements work too, we need to make sure all dependencies are compatible with the minimum requirements of the SDK.
