### PR TITLE
Fix `GrpcStreamBroadcaster` retry with a 0 interval

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,4 +14,4 @@
 
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+- Fixed retrying for `GrpcStreamBroadcaster` when the retry interval is set to 0 (before it would stop retrying if the interval was set to 0).


### PR DESCRIPTION
When the retry interval returned by the retry strategy is 0, `GrpcStreamBroadcaster` stops retrying, but it should keep going until `None` is returned instead.
