### PR TITLE
Add a `BaseApiClient` class

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,6 +12,7 @@
 
 - Add a `exception` module to provide client exceptions, including gRPC errors with one subclass per gRPC error status code.
 - `channel.parse_grpc_uri()` can now be used with `grpcio` too.
+- A new `BaseApiClient` class is introduced to provide a base class for API clients. It is strongly recommended to use this class as a base class for all API clients.
 
 ## Bug Fixes
 

--- a/src/frequenz/client/base/client.py
+++ b/src/frequenz/client/base/client.py
@@ -1,0 +1,138 @@
+# License: MIT
+# Copyright © 2024 Frequenz Energy-as-a-Service GmbH
+
+"""Base class for API clients."""
+
+import abc
+from collections.abc import Callable
+from typing import Any, Generic, Self, TypeVar
+
+from .channel import ChannelT, parse_grpc_uri
+
+StubT = TypeVar("StubT")
+
+
+class BaseApiClient(abc.ABC, Generic[StubT, ChannelT]):
+    """A base class for API clients.
+
+    This class provides a common interface for API clients that communicate with a API
+    server. It is designed to be subclassed by specific API clients that provide a more
+    specific interface.
+    """
+
+    def __init__(
+        self,
+        server_url: str,
+        create_stub: Callable[[ChannelT], StubT],
+        channel_type: type[ChannelT],
+        *,
+        auto_connect: bool = True,
+    ) -> None:
+        """Create an instance and connect to the server.
+
+        Args:
+            server_url: The URL of the server to connect to.
+            create_stub: A function that creates a stub from a channel.
+            channel_type: The type of channel to use.
+            auto_connect: Whether to automatically connect to the server. If `False`, the
+                client will not connect to the server until
+                [connect()][frequenz.client.base.client.BaseApiClient.connect] is
+                called.
+        """
+        self._server_url: str = server_url
+        self._create_stub: Callable[[ChannelT], StubT] = create_stub
+        self._channel_type: type[ChannelT] = channel_type
+        self._channel: ChannelT | None = None
+        self._stub: StubT | None = None
+        if auto_connect:
+            self.connect(server_url)
+
+    @property
+    def server_url(self) -> str:
+        """The URL of the server."""
+        return self._server_url
+
+    @property
+    def channel(self) -> ChannelT | None:
+        """The underlying gRPC channel used to communicate with the server.
+
+        If the client is not connected, this property is `None`.
+
+        Warning:
+            This channel is provided as a last resort for advanced users. It is not
+            recommended to use this property directly unless you know what you are
+            doing and you don't care about being tied to a specific gRPC library.
+        """
+        return self._channel
+
+    @property
+    def stub(self) -> StubT | None:
+        """The underlying gRPC stub.
+
+        If the client is not connected, this property is `None`.
+
+        Warning:
+            This stub is provided as a last resort for advanced users. It is not
+            recommended to use this property directly unless you know what you are
+            doing and you don't care about being tied to a specific gRPC library.
+        """
+        return self._stub
+
+    @property
+    def is_connected(self) -> bool:
+        """Whether the client is connected to the server."""
+        return self._channel is not None
+
+    def connect(self, server_url: str | None = None) -> None:
+        """Connect to the server, possibly using a new URL.
+
+        If the client is already connected and the URL is the same as the previous URL,
+        this method does nothing. If you want to force a reconnection, you can call
+        [disconnect()][frequenz.client.base.client.BaseApiClient.disconnect] first.
+
+        Args:
+            server_url: The URL of the server to connect to. If not provided, the
+                previously used URL is used.
+        """
+        if server_url is not None and server_url != self._server_url:  # URL changed
+            self._server_url = server_url
+        elif self.is_connected:
+            return
+        self._channel = parse_grpc_uri(self._server_url, self._channel_type)
+        self._stub = self._create_stub(self._channel)
+
+    async def disconnect(self) -> None:
+        """Disconnect from the server.
+
+        If the client is not connected, this method does nothing.
+        """
+        await self.__aexit__(None, None, None)
+
+    async def __aenter__(self) -> Self:
+        """Enter a context manager."""
+        self.connect()
+        return self
+
+    async def __aexit__(
+        self,
+        _exc_type: type[BaseException] | None,
+        _exc_val: BaseException | None,
+        _exc_tb: Any | None,
+    ) -> bool | None:
+        """Exit a context manager."""
+        if self._channel is None:
+            return None
+        # We need to ignore the return type here because the __aexit__ method of grpclib
+        # is not annotated correctly, it is annotated to return None but __aexit__
+        # should return a bool | None. This should be harmless if grpclib never handle
+        # any exceptions in __aexit__, so it is just a type checker issue. This is the
+        # error produced by mypy:
+        # Function does not return a value (it only ever returns None)
+        # [func-returns-value]
+        # See https://github.com/vmagamedov/grpclib/issues/193 for more details.
+        result = await self._channel.__aexit__(  # type: ignore[func-returns-value]
+            _exc_type, _exc_val, _exc_tb
+        )
+        self._channel = None
+        self._stub = None
+        return result

--- a/src/frequenz/client/base/client.py
+++ b/src/frequenz/client/base/client.py
@@ -8,6 +8,7 @@ from collections.abc import Callable
 from typing import Any, Generic, Self, TypeVar
 
 from .channel import ChannelT, parse_grpc_uri
+from .exception import ClientNotConnected
 
 StubT = TypeVar("StubT")
 
@@ -53,29 +54,35 @@ class BaseApiClient(abc.ABC, Generic[StubT, ChannelT]):
         return self._server_url
 
     @property
-    def channel(self) -> ChannelT | None:
+    def channel(self) -> ChannelT:
         """The underlying gRPC channel used to communicate with the server.
-
-        If the client is not connected, this property is `None`.
 
         Warning:
             This channel is provided as a last resort for advanced users. It is not
             recommended to use this property directly unless you know what you are
             doing and you don't care about being tied to a specific gRPC library.
+
+        Raises:
+            ClientNotConnected: If the client is not connected to the server.
         """
+        if self._channel is None:
+            raise ClientNotConnected(server_url=self.server_url, operation="channel")
         return self._channel
 
     @property
-    def stub(self) -> StubT | None:
+    def stub(self) -> StubT:
         """The underlying gRPC stub.
-
-        If the client is not connected, this property is `None`.
 
         Warning:
             This stub is provided as a last resort for advanced users. It is not
             recommended to use this property directly unless you know what you are
             doing and you don't care about being tied to a specific gRPC library.
+
+        Raises:
+            ClientNotConnected: If the client is not connected to the server.
         """
+        if self._stub is None:
+            raise ClientNotConnected(server_url=self.server_url, operation="stub")
         return self._stub
 
     @property

--- a/src/frequenz/client/base/exception.py
+++ b/src/frequenz/client/base/exception.py
@@ -142,6 +142,24 @@ class ApiClientError(Exception):
         )
 
 
+class ClientNotConnected(ApiClientError):
+    """The client is not connected to the server."""
+
+    def __init__(self, *, server_url: str, operation: str) -> None:
+        """Create a new instance.
+
+        Args:
+            server_url: The URL of the server that returned the error.
+            operation: The operation that caused the error.
+        """
+        super().__init__(
+            server_url=server_url,
+            operation=operation,
+            description="The client is not connected to the server",
+            retryable=True,
+        )
+
+
 class GrpcError(ApiClientError):
     """The gRPC server returned an error with a status code.
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,203 @@
+# License: MIT
+# Copyright © 2024 Frequenz Energy-as-a-Service GmbH
+
+"""Tests for the BaseApiClient class."""
+
+from dataclasses import dataclass
+from unittest import mock
+
+import pytest
+import pytest_mock
+
+from frequenz.client.base import _grpchacks
+from frequenz.client.base.channel import ChannelT
+from frequenz.client.base.client import BaseApiClient
+
+
+def _get_full_name(cls: type) -> str:
+    return f"{cls.__module__}.{cls.__name__}"
+
+
+def _auto_connect_name(auto_connect: bool) -> str:
+    return f"{auto_connect=}"
+
+
+@dataclass(kw_only=True, frozen=True)
+class _ClientMocks:
+    stub: mock.MagicMock
+    create_stub: mock.MagicMock
+    channel: mock.MagicMock
+    parse_grpc_uri: mock.MagicMock
+
+
+_DEFAULT_SERVER_URL = "grpc://localhost"
+
+
+def create_client_with_mocks(
+    mocker: pytest_mock.MockFixture,
+    channel_type: type[ChannelT],
+    *,
+    auto_connect: bool = True,
+    server_url: str = _DEFAULT_SERVER_URL,
+) -> tuple[BaseApiClient[mock.MagicMock, ChannelT], _ClientMocks]:
+    """Create a BaseApiClient instance with mocks."""
+    mock_stub = mock.MagicMock(name="stub")
+    mock_create_stub = mock.MagicMock(name="create_stub", return_value=mock_stub)
+    mock_channel = mock.MagicMock(name="channel", spec=channel_type)
+    mock_parse_grpc_uri = mocker.patch(
+        "frequenz.client.base.client.parse_grpc_uri", return_value=mock_channel
+    )
+    client = BaseApiClient(
+        server_url=server_url,
+        create_stub=mock_create_stub,
+        channel_type=channel_type,
+        auto_connect=auto_connect,
+    )
+    return client, _ClientMocks(
+        stub=mock_stub,
+        create_stub=mock_create_stub,
+        channel=mock_channel,
+        parse_grpc_uri=mock_parse_grpc_uri,
+    )
+
+
+@pytest.mark.parametrize(
+    "channel_type",
+    [_grpchacks.GrpcioChannel, _grpchacks.GrpclibChannel],
+    ids=_get_full_name,
+)
+@pytest.mark.parametrize("auto_connect", [True, False], ids=_auto_connect_name)
+def test_base_api_client_init(
+    channel_type: type[ChannelT],
+    auto_connect: bool,
+    mocker: pytest_mock.MockFixture,
+) -> None:
+    """Test initializing the BaseApiClient."""
+    client, mocks = create_client_with_mocks(
+        mocker, channel_type, auto_connect=auto_connect
+    )
+    assert client.server_url == _DEFAULT_SERVER_URL
+    if auto_connect:
+        mocks.parse_grpc_uri.assert_called_once_with(client.server_url, channel_type)
+        assert client.channel is mocks.channel
+        assert client.stub is mocks.stub
+        assert client.is_connected
+        mocks.create_stub.assert_called_once_with(mocks.channel)
+    else:
+        assert client.channel is None
+        assert client.stub is None
+        assert not client.is_connected
+        mocks.parse_grpc_uri.assert_not_called()
+        mocks.create_stub.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "channel_type",
+    [_grpchacks.GrpcioChannel, _grpchacks.GrpclibChannel],
+    ids=_get_full_name,
+)
+@pytest.mark.parametrize(
+    "new_server_url", [None, _DEFAULT_SERVER_URL, "grpc://localhost:50051"]
+)
+@pytest.mark.parametrize("auto_connect", [True, False], ids=_auto_connect_name)
+def test_base_api_client_connect(
+    channel_type: type[ChannelT],
+    new_server_url: str | None,
+    auto_connect: bool,
+    mocker: pytest_mock.MockFixture,
+) -> None:
+    """Test connecting the BaseApiClient."""
+    client, mocks = create_client_with_mocks(
+        mocker, channel_type, auto_connect=auto_connect
+    )
+    # We want to check only what happens when we call connect, so we reset the mocks
+    # that were called during initialization
+    mocks.parse_grpc_uri.reset_mock()
+    mocks.create_stub.reset_mock()
+
+    client.connect(new_server_url)
+
+    assert client.channel is mocks.channel
+    assert client.stub is mocks.stub
+    assert client.is_connected
+
+    same_url = new_server_url is None or new_server_url == _DEFAULT_SERVER_URL
+
+    if same_url:
+        assert client.server_url == _DEFAULT_SERVER_URL
+    else:
+        assert client.server_url == new_server_url
+
+    # If we were previously connected and the URL didn't change, the client should not
+    # reconnect
+    if auto_connect and same_url:
+        mocks.parse_grpc_uri.assert_not_called()
+        mocks.create_stub.assert_not_called()
+    else:
+        mocks.parse_grpc_uri.assert_called_once_with(client.server_url, channel_type)
+        mocks.create_stub.assert_called_once_with(mocks.channel)
+
+
+@pytest.mark.parametrize(
+    "channel_type",
+    [_grpchacks.GrpcioChannel, _grpchacks.GrpclibChannel],
+    ids=_get_full_name,
+)
+async def test_base_api_client_disconnect(
+    channel_type: type[ChannelT],
+    mocker: pytest_mock.MockFixture,
+) -> None:
+    """Test disconnecting the BaseApiClient."""
+    client, mocks = create_client_with_mocks(mocker, channel_type, auto_connect=True)
+
+    await client.disconnect()
+
+    mocks.channel.__aexit__.assert_called_once_with(None, None, None)
+    assert client.server_url == _DEFAULT_SERVER_URL
+    assert client.channel is None
+    assert client.stub is None
+    assert not client.is_connected
+
+
+# Tests for async context manager
+@pytest.mark.parametrize(
+    "channel_type",
+    [_grpchacks.GrpcioChannel, _grpchacks.GrpclibChannel],
+    ids=_get_full_name,
+)
+@pytest.mark.parametrize("auto_connect", [True, False], ids=_auto_connect_name)
+async def test_base_api_client_async_context_manager(
+    channel_type: type[ChannelT],
+    auto_connect: bool,
+    mocker: pytest_mock.MockFixture,
+) -> None:
+    """Test using the BaseApiClient as an async context manager."""
+    client, mocks = create_client_with_mocks(
+        mocker, channel_type, auto_connect=auto_connect
+    )
+    # We want to check only what happens when we enter the context manager, so we reset
+    # the mocks that were called during initialization
+    mocks.parse_grpc_uri.reset_mock()
+    mocks.create_stub.reset_mock()
+
+    async with client:
+        assert client.channel is mocks.channel
+        assert client.stub is mocks.stub
+        assert client.is_connected
+        mocks.channel.__aexit__.assert_not_called()
+        # If we were previously connected, the client should not reconnect when entering
+        # the context manager
+        if auto_connect:
+            mocks.parse_grpc_uri.assert_not_called()
+            mocks.create_stub.assert_not_called()
+        else:
+            mocks.parse_grpc_uri.assert_called_once_with(
+                client.server_url, channel_type
+            )
+            mocks.create_stub.assert_called_once_with(mocks.channel)
+
+    mocks.channel.__aexit__.assert_called_once_with(None, None, None)
+    assert client.server_url == _DEFAULT_SERVER_URL
+    assert client.channel is None
+    assert client.stub is None
+    assert not client.is_connected

--- a/tests/test_exception.py
+++ b/tests/test_exception.py
@@ -12,6 +12,7 @@ import pytest
 
 from frequenz.client.base.exception import (
     ApiClientError,
+    ClientNotConnected,
     DataLoss,
     EntityAlreadyExists,
     EntityNotFound,
@@ -31,6 +32,16 @@ from frequenz.client.base.exception import (
     UnknownError,
     UnrecognizedGrpcStatus,
 )
+
+
+def test_client_not_connected() -> None:
+    """Test the ClientNotConnected exception."""
+    exception = ClientNotConnected(server_url="grpc://localhost", operation="test")
+
+    assert exception.server_url == "grpc://localhost"
+    assert exception.operation == "test"
+    assert exception.description == "The client is not connected to the server"
+    assert exception.is_retryable is True
 
 
 class _GrpcErrorCtor(Protocol):


### PR DESCRIPTION
This class abstracts the common functionality of all the API clients. It provides a way to connect and disconnect from the server, provided as a URL, and a way to create the stubs to interact with the server.
    
It also provides an async context manager to make sure the connection is closed when the client is done.

We also add a new `ClientNotConnected` exception that is raised when performing operation on a client that is not connected to the server.
