### PR TITLE
Improve type-checking for `_grpchacks`

### DIFF
--- a/src/frequenz/client/base/client.py
+++ b/src/frequenz/client/base/client.py
@@ -137,9 +137,7 @@ class BaseApiClient(abc.ABC, Generic[StubT, ChannelT]):
         # Function does not return a value (it only ever returns None)
         # [func-returns-value]
         # See https://github.com/vmagamedov/grpclib/issues/193 for more details.
-        result = await self._channel.__aexit__(  # type: ignore[func-returns-value]
-            _exc_type, _exc_val, _exc_tb
-        )
+        result = await self._channel.__aexit__(_exc_type, _exc_val, _exc_tb)
         self._channel = None
         self._stub = None
         return result

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -45,7 +45,7 @@ def test_grpclib_parse_uri_ok(
         ssl: bool
 
     with mock.patch(
-        "frequenz.client.base.channel._grpchacks.GrpclibChannel",
+        "frequenz.client.base.channel._grpchacks.grpclib_create_channel",
         return_value=_FakeChannel(host, port, ssl),
     ):
         channel = parse_grpc_uri(uri, _grpchacks.GrpclibChannel)


### PR DESCRIPTION
The `ChannelT` `TypeVar` was causing a lot of issues because the types in it would change dynamically depending on which grpc library is installed. This transpired to user code wanting to subclass `BaseApiClient` which is less than ideal (hacks should be kept internal).

This PR improves this by adding a function to create a channel, which also avoids the need to create a lot of stub `grpcio` functions, and making `ChannelT` bound to an `AsyncContextManager[Any]` instead of the two specific channel classes we use. This interface is enough for the functionality we need from channels.

This way the hacks don't leak to the type system, which was the main issue.
