### PR TITLE
Use `netloc` from `urlparse` to specify the host

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,4 +14,4 @@
 
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+- Fixes a bug in creating grpc channels from ipv6 URIs.

--- a/src/frequenz/client/base/channel.py
+++ b/src/frequenz/client/base/channel.py
@@ -110,9 +110,9 @@ def parse_grpc_uri(
 
     options = _parse_query_params(uri, parsed_uri.query)
 
-    host = parsed_uri.hostname
-    port = parsed_uri.port or defaults.port
-    target = f"{host}:{port}"
+    target = (
+        parsed_uri.netloc if parsed_uri.port else f"{parsed_uri.netloc}:{defaults.port}"
+    )
 
     ssl = defaults.ssl.enabled if options.ssl is None else options.ssl
     if ssl:


### PR DESCRIPTION
This is because `netloc` is formatted to be the network location, and wraps ipv6 in square brackets, which we lose if we just use the `host` field.

`netloc` also contains the port if a port was in the original uri.  We need to append the default port only if the original uri didn't have a port.

This fixes an issue when creating a grpc Channel with ipv6 addresses.