### PR TITLE
Log when stopping `GrpcStreamBroadcaster` instances

### DIFF
--- a/src/frequenz/client/base/streaming.py
+++ b/src/frequenz/client/base/streaming.py
@@ -88,6 +88,7 @@ class GrpcStreamBroadcaster(Generic[InputT, OutputT]):
 
     async def stop(self) -> None:
         """Stop the streaming helper."""
+        _logger.info("%s: stopping the stream", self._stream_name)
         if self._task.done():
             return
         self._task.cancel()

--- a/tests/streaming/test_grpc_stream_broadcaster.py
+++ b/tests/streaming/test_grpc_stream_broadcaster.py
@@ -218,6 +218,11 @@ async def test_streaming_error(  # pylint: disable=too-many-arguments
             '\tdebug_error_string = "mock debug_error_string"\n'
             ">.",
         ),
+        (
+            "frequenz.client.base.streaming",
+            logging.INFO,
+            "test_helper: stopping the stream",
+        ),
     ]
 
 


### PR DESCRIPTION
There's already a similar log message when starting to stream.