### PR TITLE
Bump the minimum dependency of `grpcio`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,5 +7,5 @@
 ## Upgrading
 
 * Updated `protobuf` dependency range: changed from `>=4.21.6, <6` to `>=5.29.2, <7`
-* The minimum dependency for `typing-extensions` is now `>=4.6.0` to be compatible with Python 3.12
-
+* The minimum dependency for `typing-extensions` is now `4.6.0` to be compatible with Python 3.12
+* The minimum dependency for `grpcio` is now `1.59` to be compatible with Python 3.12

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 requires-python = ">= 3.11, < 4"
 dependencies = [
   "frequenz-channels >= 1.6.1, < 2",
-  "grpcio >= 1.54.2, < 2",
+  "grpcio >= 1.59, < 2",
   "protobuf >= 5.29.2, < 7",
   "typing-extensions >= 4.6.0, < 5",
 ]


### PR DESCRIPTION
This is to be compatible with Python 3.12.

Also improve slightly the previous release notes item.
