### PR TITLE
Bring the metadata keys in line with the server

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,3 +9,7 @@
 * Updated `protobuf` dependency range: changed from `>=4.21.6, <6` to `>=5.29.2, <7`
 * The minimum dependency for `typing-extensions` is now `4.6.0` to be compatible with Python 3.12
 * The minimum dependency for `grpcio` is now `1.59` to be compatible with Python 3.12
+
+## Bug Fixes
+
+* Fixed keys of signature to match what fuse-rs expects

--- a/src/frequenz/client/base/authentication.py
+++ b/src/frequenz/client/base/authentication.py
@@ -74,4 +74,4 @@ class AuthenticationInterceptor(UnaryUnaryClientInterceptor):  # type: ignore[ty
         if client_call_details.metadata is None:
             client_call_details.metadata = Metadata()
 
-        client_call_details.metadata["x-key"] = self._key
+        client_call_details.metadata["key"] = self._key

--- a/src/frequenz/client/base/signing.py
+++ b/src/frequenz/client/base/signing.py
@@ -85,7 +85,7 @@ class SigningInterceptor(UnaryUnaryClientInterceptor):  # type: ignore[type-arg]
             )
             return
 
-        key: Any = client_call_details.metadata.get("x-key")
+        key: Any = client_call_details.metadata.get("key")
         if key is None:
             _logger.error("No key found in metadata, cannot sign the request.")
             return
@@ -96,6 +96,6 @@ class SigningInterceptor(UnaryUnaryClientInterceptor):  # type: ignore[type-arg]
 
         hmac_obj.update(client_call_details.method.encode())
 
-        client_call_details.metadata["x-ts"] = ts
-        client_call_details.metadata["x-nonce"] = nonce
-        client_call_details.metadata["x-hmac"] = urlsafe_b64encode(hmac_obj.digest())
+        client_call_details.metadata["ts"] = ts
+        client_call_details.metadata["nonce"] = nonce
+        client_call_details.metadata["sig"] = urlsafe_b64encode(hmac_obj.digest())

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -25,4 +25,4 @@ async def test_auth_interceptor() -> None:
 
     auth_interceptor.add_auth_header(client_call_details)
 
-    assert metadata["x-key"] == "my_key"
+    assert metadata["key"] == "my_key"

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -16,13 +16,13 @@ async def test_sign_interceptor() -> None:
     sign: SigningOptions = SigningOptions(secret="my_secret")
     sign_interceptor: SigningInterceptor = SigningInterceptor(options=sign)
 
-    metadata: dict[str, str | bytes] = {"x-key": "my_key"}
+    metadata: dict[str, str | bytes] = {"key": "my_key"}
 
     client_call_details = mock.MagicMock(method="my_rpc")
     client_call_details.metadata = metadata
 
     sign_interceptor.add_hmac(client_call_details, b"1634567890", b"123456789")
 
-    assert metadata["x-hmac"] == "NJDvrkRZhOPekn5AvPiaJsYTJYCgnLzA-LQFC2D7GNE=".encode(
+    assert metadata["sig"] == "NJDvrkRZhOPekn5AvPiaJsYTJYCgnLzA-LQFC2D7GNE=".encode(
         "utf-8"
     )


### PR DESCRIPTION
The keys currently used to store the authentication and signature metadata use the `x-***` pattern. However, the server just used plain names (e.g. `x-key` vs. `key`).
This changes the used metadata keys to be the same as the ones used by the server.