### PR TITLE
Fix handling of unexpected exceptions in `GrpcStreamBroadcaster`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,8 +2,8 @@
 
 ## Features
 
-* Added support for HMAC signing of UnaryUnary client messages
-* Added support for HMAC signing of UnaryStream client messages
+* Added support for HMAC signing of `UnaryUnary` client messages
+* Added support for HMAC signing of `UnaryStream` client messages
 
 ## Upgrading
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,3 +14,7 @@
 ## Bug Fixes
 
 * Fixed keys of signature to match what fuse-rs expects
+* `GrpcStreamBroadcaster` will now correctly try to restart on unexpected errors.
+
+    Before if an unexpected exception was raised by the stream method, the
+    internal task would silently finish and never start again.

--- a/src/frequenz/client/base/streaming.py
+++ b/src/frequenz/client/base/streaming.py
@@ -111,6 +111,12 @@ class GrpcStreamBroadcaster(Generic[InputT, OutputT]):
                     await sender.send(self._transform(msg))
             except grpc.aio.AioRpcError as err:
                 error = err
+            except Exception as err:  # pylint: disable=broad-except
+                _logger.exception(
+                    "%s: raise an unexpected exception",
+                    self._stream_name,
+                )
+                error = err
             if error is None and not self._retry_on_exhausted_stream:
                 _logger.info(
                     "%s: connection closed, stream exhausted", self._stream_name


### PR DESCRIPTION
`GrpcStreamBroadcaster` will now correctly try to restart on unexpected errors.

Before if an unexpected exception was raised by the stream method, the internal task would silently finish and never start again.
