### PR TITLE
Add missing retry strategy reset in streaming

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,3 +9,7 @@
 * `GrpcStreamBroadcaster`: Fix potential long delays on retries, and giving up early if the number of retries is limited.
 
    The retry strategy was not reset after a successful start of the stream, so the back-off delays would accumulate over multiple retries and eventually give up if the number of retries were limited, even if there was a successful start of the stream in between. Now we properly reset the retry strategy after a successful start of the stream (successfully receiving the first item from the stream).
+
+* `GrpcStreamBroadcaster`: Fix `StreamStarted` event firing too soon.
+
+   The `StreamStarted` event was being fired as soon as the streamming method was called, but that doesn't mean that a streamming connection was established with the server at all, which can give a false impression that the stream is active and working. Now we wait until we receive the initial metadata from the server before firing the `StreamStarted` event. That should give users a better indication that the stream is actually active and working without having to wait for the first item to be received, which can take a long time for some low-frequency streams.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,17 +1,11 @@
 # Frequenz Client Base Library Release Notes
 
-## Summary
-
-<!-- Here goes a general summary of what this release is about -->
-
 ## Upgrading
 
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
-
-## New Features
-
-<!-- Here goes the main new features and examples or instructions on how to use them -->
+* There is very minor breaking change in this release, `GrpcStreamBroadcaster` now requires a `grpc.aio.UnaryStreamCall` instead of a `AsyncIterable` for the `stream_method` argument. In practice all users should be passing a `grpc.aio.UnaryStreamCall` already, so this should not affect anyone unless they are doing something very strange.
 
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+* `GrpcStreamBroadcaster`: Fix potential long delays on retries, and giving up early if the number of retries is limited.
+
+   The retry strategy was not reset after a successful start of the stream, so the back-off delays would accumulate over multiple retries and eventually give up if the number of retries were limited, even if there was a successful start of the stream in between. Now we properly reset the retry strategy after a successful start of the stream (successfully receiving the first item from the stream).

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,36 +6,11 @@
 
 ## Upgrading
 
-* Updated interface and behavior for HMAC
-
-    This introduces a new positional argument to `parse_grpc_uri`.
-    If calling this function manually and passing `ChannelOptions`, it is recommended
-    to switch to passing `ChannelOptions` via keyword argument.
-
-* All parameters of the Streamers `new_receiver` method are now keyword-only arguments. This means that you must specify them by name when calling the method, e.g.:
-
-    ```python
-    recv = streamer.new_receiver(max_size=50, warn_on_overflow=True)
-    ```
+<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
 
 ## New Features
 
-* The streaming client, when using `new_receiver(include_events=True)`, will now return a receiver that yields stream notification events, such as `StreamStarted`, `StreamRetrying`, and `StreamFatalError`. This allows you to monitor the state of the stream:
-
-    ```python
-    recv = streamer.new_receiver(include_events=True)
-
-    for msg in recv:
-        match msg:
-            case StreamStarted():
-                print("Stream started")
-            case StreamRetrying(delay, error):
-                print(f"Stream stopped and will retry in {delay}: {error or 'closed'}")
-            case StreamFatalError(error):
-                print(f"Stream will stop because of a fatal error: {error}")
-            case int() as output:
-                print(f"Received message: {output}")
-    ```
+<!-- Here goes the main new features and examples or instructions on how to use them -->
 
 ## Bug Fixes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 requires-python = ">= 3.11, < 4"
 dependencies = [
-  "frequenz-channels >= 1.6.1, < 2",
+  "frequenz-channels >= 1.8.0, < 2",
   "grpcio >= 1.59, < 2",
   "protobuf >= 5.29.2, < 7",
   "typing-extensions >= 4.6.0, < 5",

--- a/src/frequenz/client/base/streaming.py
+++ b/src/frequenz/client/base/streaming.py
@@ -265,9 +265,9 @@ class GrpcStreamBroadcaster(Generic[InputT, OutputT]):
             await self._task
         except asyncio.CancelledError:
             pass
-        await self._data_channel.close()
+        await self._data_channel.aclose()
         if self._event_channel is not None:
-            await self._event_channel.close()
+            await self._event_channel.aclose()
 
     async def _run(self) -> None:
         """Run the streaming helper."""
@@ -303,9 +303,9 @@ class GrpcStreamBroadcaster(Generic[InputT, OutputT]):
                 _logger.info(
                     "%s: connection closed, stream exhausted", self._stream_name
                 )
-                await self._data_channel.close()
+                await self._data_channel.aclose()
                 if self._event_channel is not None:
-                    await self._event_channel.close()
+                    await self._event_channel.aclose()
                 break
 
             interval = self._retry_strategy.next_interval()
@@ -319,9 +319,9 @@ class GrpcStreamBroadcaster(Generic[InputT, OutputT]):
                 )
                 if error is not None and self._event_sender:
                     await self._event_sender.send(StreamFatalError(error))
-                await self._data_channel.close()
+                await self._data_channel.aclose()
                 if self._event_channel is not None:
-                    await self._event_channel.close()
+                    await self._event_channel.aclose()
                 break
             _logger.warning(
                 "%s: connection ended, retrying %s in %0.3f seconds. %s.",

--- a/src/frequenz/client/base/streaming.py
+++ b/src/frequenz/client/base/streaming.py
@@ -8,7 +8,7 @@ import logging
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import AsyncIterable, Generic, Literal, TypeAlias, TypeVar, overload
+from typing import Generic, Literal, TypeAlias, TypeVar, overload
 
 import grpc.aio
 
@@ -17,6 +17,10 @@ from frequenz import channels
 from . import retry
 
 _logger = logging.getLogger(__name__)
+
+
+RequestT = TypeVar("RequestT")
+"""The request type of the stream."""
 
 
 InputT = TypeVar("InputT")
@@ -76,31 +80,20 @@ class GrpcStreamBroadcaster(Generic[InputT, OutputT]):
 
     Example:
         ```python
+        from typing import Any
         from frequenz.client.base import (
             GrpcStreamBroadcaster,
             StreamFatalError,
             StreamRetrying,
             StreamStarted,
         )
-        from frequenz.channels import Receiver # Assuming Receiver is available
-
-        # Dummy async iterable for demonstration
-        async def async_range(fail_after: int = -1) -> AsyncIterable[int]:
-            for i in range(10):
-                if fail_after != -1 and i >= fail_after:
-                    raise grpc.aio.AioRpcError(
-                        code=grpc.StatusCode.UNAVAILABLE,
-                        initial_metadata=grpc.aio.Metadata(),
-                        trailing_metadata=grpc.aio.Metadata(),
-                        details="Simulated error"
-                    )
-                yield i
-                await asyncio.sleep(0.1)
+        from frequenz.channels import Receiver
 
         async def main():
+            stub: Any = ...  # The gRPC stub
             streamer = GrpcStreamBroadcaster(
                 stream_name="example_stream",
-                stream_method=lambda: async_range(fail_after=3),
+                stream_method=stub.MyStreamingMethod,
                 transform=lambda msg: msg * 2, # transform messages
                 retry_on_exhausted_stream=False,
             )
@@ -156,7 +149,7 @@ class GrpcStreamBroadcaster(Generic[InputT, OutputT]):
     def __init__(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         self,
         stream_name: str,
-        stream_method: Callable[[], AsyncIterable[InputT]],
+        stream_method: Callable[[], grpc.aio.UnaryStreamCall[RequestT, InputT]],
         transform: Callable[[InputT], OutputT],
         retry_strategy: retry.Strategy | None = None,
         retry_on_exhausted_stream: bool = False,
@@ -287,6 +280,12 @@ class GrpcStreamBroadcaster(Generic[InputT, OutputT]):
             try:
                 call = self._stream_method()
 
+                # We await for the initial metadata before sending a
+                # StreamStarted event. This is the best indication we have of a
+                # successful connection without delaying it until the first
+                # message is received, which might happen a long time after the
+                # "connection" was established.
+                await call.initial_metadata()
                 if self._event_sender:
                     await self._event_sender.send(StreamStarted())
 

--- a/src/frequenz/client/base/streaming.py
+++ b/src/frequenz/client/base/streaming.py
@@ -199,7 +199,7 @@ class GrpcStreamBroadcaster(Generic[InputT, OutputT]):
         *,
         maxsize: int = 50,
         warn_on_overflow: bool = True,
-        include_events: Literal[True],
+        include_events: bool,
     ) -> channels.Receiver[StreamEvent | OutputT]: ...
 
     def new_receiver(
@@ -208,7 +208,7 @@ class GrpcStreamBroadcaster(Generic[InputT, OutputT]):
         maxsize: int = 50,
         warn_on_overflow: bool = True,
         include_events: bool = False,
-    ) -> channels.Receiver[OutputT] | channels.Receiver[StreamEvent | OutputT]:
+    ) -> channels.Receiver[StreamEvent | OutputT]:
         """Create a new receiver for the stream.
 
         Args:

--- a/src/frequenz/client/base/streaming.py
+++ b/src/frequenz/client/base/streaming.py
@@ -282,6 +282,7 @@ class GrpcStreamBroadcaster(Generic[InputT, OutputT]):
 
         while True:
             error: Exception | None = None
+            first_message_received = False
             _logger.info("%s: starting to stream", self._stream_name)
             try:
                 call = self._stream_method()
@@ -290,9 +291,14 @@ class GrpcStreamBroadcaster(Generic[InputT, OutputT]):
                     await self._event_sender.send(StreamStarted())
 
                 async for msg in call:
+                    first_message_received = True
                     await data_sender.send(self._transform(msg))
+
             except grpc.aio.AioRpcError as err:
                 error = err
+
+            if first_message_received:
+                self._retry_strategy.reset()
 
             if error is None and not self._retry_on_exhausted_stream:
                 _logger.info(

--- a/tests/streaming/test_grpc_stream_broadcaster.py
+++ b/tests/streaming/test_grpc_stream_broadcaster.py
@@ -57,6 +57,18 @@ def make_error() -> grpc.aio.AioRpcError:
     )
 
 
+def unary_stream_call_mock(
+    name: str, side_effect: Callable[[], AsyncIterator[object]]
+) -> mock.MagicMock:
+    """Create a new mocked unary stream call."""
+    # Sadly we can't use spec here because grpc.aio.UnaryStreamCall seems to be
+    # dynamic and mock doesn't find `__aiter__` in it when creating the spec.
+    call_mock = mock.MagicMock(name=name)
+    call_mock.__aiter__.side_effect = side_effect
+    call_mock.initial_metadata = mock.AsyncMock()
+    return call_mock
+
+
 @pytest.fixture
 async def ok_helper(
     no_retry: mock.MagicMock,  # pylint: disable=redefined-outer-name
@@ -72,9 +84,15 @@ async def ok_helper(
             yield i
             await asyncio.sleep(0)  # Yield control to the event loop
 
+    rpc_mock = mock.MagicMock(
+        name="ok_helper_method",
+        side_effect=lambda: unary_stream_call_mock(
+            "ok_helper_unary_stream_call", asynciter
+        ),
+    )
     helper = streaming.GrpcStreamBroadcaster(
         stream_name="test_helper",
-        stream_method=asynciter,
+        stream_method=rpc_mock,
         transform=_transformer,
         retry_strategy=no_retry,
         retry_on_exhausted_stream=retry_on_exhausted_stream,

--- a/tests/streaming/test_grpc_stream_broadcaster.py
+++ b/tests/streaming/test_grpc_stream_broadcaster.py
@@ -373,8 +373,6 @@ async def test_messages_on_retry(
     assert items == [
         "transformed_0",
         "transformed_1",
-        "transformed_0",
-        "transformed_1",
     ]
     if include_events:
         assert events == [

--- a/tests/streaming/test_grpc_stream_broadcaster.py
+++ b/tests/streaming/test_grpc_stream_broadcaster.py
@@ -65,16 +65,16 @@ async def ok_helper(
 ) -> AsyncIterator[streaming.GrpcStreamBroadcaster[int, str]]:
     """Fixture for GrpcStreamBroadcaster."""
 
-    async def asynciter(ready_event: asyncio.Event) -> AsyncIterator[int]:
+    async def asynciter() -> AsyncIterator[int]:
         """Mock async iterator."""
-        await ready_event.wait()
+        await receiver_ready_event.wait()
         for i in range(5):
             yield i
             await asyncio.sleep(0)  # Yield control to the event loop
 
     helper = streaming.GrpcStreamBroadcaster(
         stream_name="test_helper",
-        stream_method=lambda: asynciter(receiver_ready_event),
+        stream_method=asynciter,
         transform=_transformer,
         retry_strategy=no_retry,
         retry_on_exhausted_stream=retry_on_exhausted_stream,

--- a/tests/streaming/test_grpc_stream_broadcaster.py
+++ b/tests/streaming/test_grpc_stream_broadcaster.py
@@ -242,16 +242,6 @@ async def test_streaming_success(
     ]
 
 
-class _NamedMagicMock(mock.MagicMock):
-    """Mock with a name."""
-
-    def __str__(self) -> str:
-        return self._mock_name  # type: ignore
-
-    def __repr__(self) -> str:
-        return self._mock_name  # type: ignore
-
-
 @pytest.mark.parametrize("successes", [0, 1, 5])
 async def test_streaming_error(  # pylint: disable=too-many-arguments
     successes: int,

--- a/tests/streaming/test_grpc_stream_broadcaster.py
+++ b/tests/streaming/test_grpc_stream_broadcaster.py
@@ -399,3 +399,44 @@ async def test_messages_on_retry(
         ]
     else:
         assert events == []
+
+
+@mock.patch(
+    "frequenz.client.base.streaming.asyncio.sleep", autospec=True, wraps=asyncio.sleep
+)
+async def test_retry_reset(
+    mock_sleep: mock.MagicMock,
+    receiver_ready_event: asyncio.Event,  # pylint: disable=redefined-outer-name
+) -> None:
+    """Test that retry strategy resets after a successful start."""
+    # Use a mock retry strategy so we can assert reset() was called.
+    mock_retry = mock.MagicMock(spec=retry.Strategy)
+    # Simulate one retry interval then exhaustion.
+    mock_retry.next_interval.side_effect = [0.01, 0.01, None]
+    mock_retry.copy.return_value = mock_retry
+    mock_retry.get_progress.return_value = "mock progress"
+
+    # The rpc will yield one message then raise, so the strategy should be reset
+    # after the successful start (i.e. after first message received).
+    helper = streaming.GrpcStreamBroadcaster(
+        stream_name="test_helper",
+        stream_method=erroring_rpc_mock(
+            make_error(), receiver_ready_event, num_successes=1
+        ),
+        transform=_transformer,
+        retry_strategy=mock_retry,
+        retry_on_exhausted_stream=True,
+    )
+
+    async with AsyncExitStack() as stack:
+        stack.push_async_callback(helper.stop)
+
+        receiver = helper.new_receiver()
+        receiver_ready_event.set()
+        _ = await _split_message(receiver)
+
+    # reset() should have been called once after the successful start.
+    mock_retry.reset.assert_called_once()
+
+    # One sleep for the single retry interval.
+    mock_sleep.assert_has_calls([mock.call(0.01), mock.call(0.01)])

--- a/tests/streaming/test_grpc_stream_broadcaster.py
+++ b/tests/streaming/test_grpc_stream_broadcaster.py
@@ -126,7 +126,7 @@ class _ErroringAsyncIter(AsyncIterator[int]):
     """Async iterator that raises an error after a certain number of successes."""
 
     def __init__(
-        self, error: Exception, ready_event: asyncio.Event, num_successes: int = 0
+        self, error: Exception, ready_event: asyncio.Event, *, num_successes: int = 0
     ):
         self._error = error
         self._ready_event = ready_event
@@ -155,7 +155,7 @@ def erroring_rpc_mock(
 ) -> mock.MagicMock:
     """Fixture for mocked erroring rpc."""
     # In this case we want to keep the state of the erroring call
-    erroring_iter = _ErroringAsyncIter(error, ready_event, num_successes)
+    erroring_iter = _ErroringAsyncIter(error, ready_event, num_successes=num_successes)
     call_mock = unary_stream_call_mock(
         "erroring_unary_stream_call", lambda: erroring_iter
     )

--- a/tests/streaming/test_grpc_stream_broadcaster.py
+++ b/tests/streaming/test_grpc_stream_broadcaster.py
@@ -141,9 +141,18 @@ class _ErroringAsyncIter(AsyncIterator[int]):
             raise self._error
         return self._current
 
+    async def initial_metadata(self) -> None:
+        """Mock initial metadata method."""
+        if self._current >= self._num_successes:
+            raise self._error
+
 
 def erroring_rpc_mock(
-    error: Exception, ready_event: asyncio.Event, num_successes: int = 0
+    error: Exception,
+    ready_event: asyncio.Event,
+    *,
+    num_successes: int = 0,
+    should_error_on_initial_metadata_too: bool = False,
 ) -> mock.MagicMock:
     """Fixture for mocked erroring rpc."""
     # In this case we want to keep the state of the erroring call
@@ -151,6 +160,8 @@ def erroring_rpc_mock(
     call_mock = unary_stream_call_mock(
         "erroring_unary_stream_call", lambda: erroring_iter
     )
+    if should_error_on_initial_metadata_too:
+        call_mock.initial_metadata.side_effect = erroring_iter.initial_metadata
     rpc_mock = mock.MagicMock(name="erroring_rpc", return_value=call_mock)
 
     return rpc_mock
@@ -342,10 +353,18 @@ async def test_retry_next_interval_zero(  # pylint: disable=too-many-arguments
     ]
 
 
-@pytest.mark.parametrize("include_events", [True, False])
+@pytest.mark.parametrize(
+    "include_events", [True, False], ids=["with_events", "without_events"]
+)
+@pytest.mark.parametrize(
+    "error_in_metadata",
+    [True, False],
+    ids=["with_initial_metadata_error", "iterator_error_only"],
+)
 async def test_messages_on_retry(
     receiver_ready_event: asyncio.Event,  # pylint: disable=redefined-outer-name
     include_events: Literal[True] | Literal[False],
+    error_in_metadata: bool,
 ) -> None:
     """Test that messages are sent on retry."""
     # We need to use a specific instance for all the test here because 2 errors created
@@ -355,7 +374,12 @@ async def test_messages_on_retry(
 
     helper = streaming.GrpcStreamBroadcaster(
         stream_name="test_helper",
-        stream_method=erroring_rpc_mock(error, receiver_ready_event, num_successes=2),
+        stream_method=erroring_rpc_mock(
+            error,
+            receiver_ready_event,
+            num_successes=2,
+            should_error_on_initial_metadata_too=error_in_metadata,
+        ),
         transform=_transformer,
         retry_strategy=retry.LinearBackoff(limit=1, interval=0.0, jitter=0.0),
         retry_on_exhausted_stream=True,
@@ -375,10 +399,13 @@ async def test_messages_on_retry(
         "transformed_1",
     ]
     if include_events:
+        extra_events: list[StreamEvent] = []
+        if not error_in_metadata:
+            extra_events.append(StreamStarted())
         assert events == [
             StreamStarted(),
             StreamRetrying(timedelta(seconds=0.0), error),
-            StreamStarted(),
+            *extra_events,
             StreamFatalError(error),
         ]
     else:

--- a/tests/streaming/test_grpc_stream_broadcaster.py
+++ b/tests/streaming/test_grpc_stream_broadcaster.py
@@ -8,7 +8,6 @@ import logging
 from collections.abc import AsyncIterator, Callable
 from contextlib import AsyncExitStack
 from datetime import timedelta
-from typing import Literal
 from unittest import mock
 
 import grpc
@@ -308,7 +307,7 @@ async def test_streaming_error(  # pylint: disable=too-many-arguments
 async def test_retry_next_interval_zero(  # pylint: disable=too-many-arguments
     receiver_ready_event: asyncio.Event,  # pylint: disable=redefined-outer-name
     caplog: pytest.LogCaptureFixture,
-    include_events: Literal[True] | Literal[False],
+    include_events: bool,
 ) -> None:
     """Test retry logic when next_interval returns 0."""
     caplog.set_level(logging.WARNING)
@@ -363,7 +362,7 @@ async def test_retry_next_interval_zero(  # pylint: disable=too-many-arguments
 )
 async def test_messages_on_retry(
     receiver_ready_event: asyncio.Event,  # pylint: disable=redefined-outer-name
-    include_events: Literal[True] | Literal[False],
+    include_events: bool,
     error_in_metadata: bool,
 ) -> None:
     """Test that messages are sent on retry."""

--- a/tests/streaming/test_grpc_stream_broadcaster.py
+++ b/tests/streaming/test_grpc_stream_broadcaster.py
@@ -5,7 +5,7 @@
 
 import asyncio
 import logging
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from contextlib import AsyncExitStack
 from datetime import timedelta
 from typing import Literal
@@ -142,6 +142,20 @@ class _ErroringAsyncIter(AsyncIterator[int]):
         return self._current
 
 
+def erroring_rpc_mock(
+    error: Exception, ready_event: asyncio.Event, num_successes: int = 0
+) -> mock.MagicMock:
+    """Fixture for mocked erroring rpc."""
+    # In this case we want to keep the state of the erroring call
+    erroring_iter = _ErroringAsyncIter(error, ready_event, num_successes)
+    call_mock = unary_stream_call_mock(
+        "erroring_unary_stream_call", lambda: erroring_iter
+    )
+    rpc_mock = mock.MagicMock(name="erroring_rpc", return_value=call_mock)
+
+    return rpc_mock
+
+
 @pytest.mark.parametrize("retry_on_exhausted_stream", [True])
 async def test_streaming_success_retry_on_exhausted(
     ok_helper: streaming.GrpcStreamBroadcaster[
@@ -242,7 +256,7 @@ async def test_streaming_error(  # pylint: disable=too-many-arguments
 
     helper = streaming.GrpcStreamBroadcaster(
         stream_name="test_helper",
-        stream_method=lambda: _ErroringAsyncIter(
+        stream_method=erroring_rpc_mock(
             error, receiver_ready_event, num_successes=successes
         ),
         transform=_transformer,
@@ -294,7 +308,7 @@ async def test_retry_next_interval_zero(  # pylint: disable=too-many-arguments
     mock_retry.get_progress.return_value = "mock progress"
     helper = streaming.GrpcStreamBroadcaster(
         stream_name="test_helper",
-        stream_method=lambda: _ErroringAsyncIter(error, receiver_ready_event),
+        stream_method=erroring_rpc_mock(error, receiver_ready_event),
         transform=_transformer,
         retry_strategy=mock_retry,
     )
@@ -341,9 +355,7 @@ async def test_messages_on_retry(
 
     helper = streaming.GrpcStreamBroadcaster(
         stream_name="test_helper",
-        stream_method=lambda: _ErroringAsyncIter(
-            error, receiver_ready_event, num_successes=2
-        ),
+        stream_method=erroring_rpc_mock(error, receiver_ready_event, num_successes=2),
         transform=_transformer,
         retry_strategy=retry.LinearBackoff(limit=1, interval=0.0, jitter=0.0),
         retry_on_exhausted_stream=True,


### PR DESCRIPTION
After the streaming started successfully we should reset the retry strategy, so next time there is a failure we can retry from the beginning of the retry strategy again.
