### PR TITLE
Improve streamer events

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -17,9 +17,9 @@
 
     for msg in recv:
         match msg:
-            case StreamStartedEvent():
+            case StreamStarted():
                 print("Stream started")
-            case StreamStoppedEvent() as event:
+            case StreamStopped() as event:
                 print(f"Stream stopped, reason {event.exception}, retry in {event.retry_time}")
             case int() as output:
                 print(f"Received message: {output}")

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,8 +19,8 @@
         match msg:
             case StreamStarted():
                 print("Stream started")
-            case StreamStopped(delay, error):
-                print(f"Stream stopped, reason {error}, retry in {delay}")
+            case StreamRetrying(delay, error):
+                print(f"Stream stopped and will retry in {delay}: {error or 'closed'}")
             case StreamFatalError(error):
                 print(f"Stream will stop because of a fatal error: {error}")
             case int() as output:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,8 +19,8 @@
         match msg:
             case StreamStarted():
                 print("Stream started")
-            case StreamStopped() as event:
-                print(f"Stream stopped, reason {event.exception}, retry in {event.retry_time}")
+            case StreamStopped(delay, error):
+                print(f"Stream stopped, reason {error}, retry in {delay}")
             case int() as output:
                 print(f"Received message: {output}")
     ```

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,16 +13,16 @@
 * The streaming client now also sends state change events out. Usage example:
 
     ```python
-        recv = streamer.new_receiver()
+    recv = streamer.new_receiver()
 
-        for msg in recv:
-            match msg:
-                case StreamStartedEvent():
-                    print("Stream started")
-                case StreamStoppedEvent() as event:
-                    print(f"Stream stopped, reason {event.exception}, retry in {event.retry_time}")
-                case int() as output:
-                    print(f"Received message: {output}")
+    for msg in recv:
+        match msg:
+            case StreamStartedEvent():
+                print("Stream started")
+            case StreamStoppedEvent() as event:
+                print(f"Stream stopped, reason {event.exception}, retry in {event.retry_time}")
+            case int() as output:
+                print(f"Received message: {output}")
     ```
 
 ## Bug Fixes

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -21,6 +21,8 @@
                 print("Stream started")
             case StreamStopped(delay, error):
                 print(f"Stream stopped, reason {error}, retry in {delay}")
+            case StreamFatalError(error):
+                print(f"Stream will stop because of a fatal error: {error}")
             case int() as output:
                 print(f"Received message: {output}")
     ```

--- a/src/frequenz/client/base/streaming.py
+++ b/src/frequenz/client/base/streaming.py
@@ -46,8 +46,6 @@ StreamEvent: TypeAlias = StreamStartedEvent | StreamStoppedEvent
 """Type alias for the events that can be sent over the stream."""
 
 
-# Ignore D412: "No blank lines allowed between a section header and its content"
-# flake8: noqa: D412
 class GrpcStreamBroadcaster(Generic[InputT, OutputT]):
     """Helper class to handle grpc streaming methods.
 
@@ -65,30 +63,29 @@ class GrpcStreamBroadcaster(Generic[InputT, OutputT]):
     state of the stream.
 
     Example:
+        ```python
+        from frequenz.client.base import GrpcStreamBroadcaster
 
-    ```python
-    from frequenz.client.base import GrpcStreamBroadcaster
+        def async_range() -> AsyncIterable[int]:
+            yield from range(10)
 
-    def async_range() -> AsyncIterable[int]:
-        yield from range(10)
+        streamer = GrpcStreamBroadcaster(
+            stream_name="example_stream",
+            stream_method=async_range,
+            transform=lambda msg: msg,
+        )
 
-    streamer = GrpcStreamBroadcaster(
-        stream_name="example_stream",
-        stream_method=async_range,
-        transform=lambda msg: msg,
-    )
+        recv = streamer.new_receiver()
 
-    recv = streamer.new_receiver()
-
-    for msg in recv:
-        match msg:
-            case StreamStartedEvent():
-                print("Stream started")
-            case StreamStoppedEvent() as event:
-                print(f"Stream stopped, reason {event.exception}, retry in {event.retry_time}")
-            case int() as output:
-                print(f"Received message: {output}")
-    ```
+        for msg in recv:
+            match msg:
+                case StreamStartedEvent():
+                    print("Stream started")
+                case StreamStoppedEvent() as event:
+                    print(f"Stream stopped, reason {event.exception}, retry in {event.retry_time}")
+                case int() as output:
+                    print(f"Received message: {output}")
+        ```
     """
 
     def __init__(  # pylint: disable=too-many-arguments,too-many-positional-arguments

--- a/src/frequenz/client/base/streaming.py
+++ b/src/frequenz/client/base/streaming.py
@@ -32,14 +32,18 @@ class StreamStarted:
 
 
 @dataclass(frozen=True)
-class StreamStopped:
+class StreamRetrying:
     """Event indicating that the stream has stopped."""
 
-    retry_time: timedelta | None = None
-    """Time to wait before retrying the stream, if applicable."""
+    delay: timedelta
+    """Time to wait before retrying to start the stream again."""
 
     exception: Exception | None = None
-    """The exception that caused the stream to stop, if any."""
+    """The exception that caused the stream to stop, if any.
+
+    If `None`, the stream was stopped without an error, e.g. the server closed the
+    stream.
+    """
 
 
 @dataclass(frozen=True)
@@ -50,7 +54,7 @@ class StreamFatalError:
     """The exception that caused the stream to stop."""
 
 
-StreamEvent: TypeAlias = StreamStarted | StreamStopped | StreamFatalError
+StreamEvent: TypeAlias = StreamStarted | StreamRetrying | StreamFatalError
 """Type alias for the events that can be sent over the stream."""
 
 
@@ -89,8 +93,8 @@ class GrpcStreamBroadcaster(Generic[InputT, OutputT]):
             match msg:
                 case StreamStarted():
                     print("Stream started")
-                case StreamStopped(delay, error):
-                    print(f"Stream stopped, reason {error}, retry in {delay}")
+                case StreamRetrying(delay, error):
+                    print(f"Stream stopped and will retry in {delay}: {error or 'closed'}")
                 case StreamFatalError(error):
                     print(f"Stream will stop because of a fatal error: {error}")
                 case int() as output:
@@ -184,23 +188,14 @@ class GrpcStreamBroadcaster(Generic[InputT, OutputT]):
             except grpc.aio.AioRpcError as err:
                 error = err
 
-            interval = self._retry_strategy.next_interval()
-
-            await sender.send(
-                StreamStopped(
-                    retry_time=(
-                        timedelta(seconds=interval) if interval is not None else None
-                    ),
-                    exception=error,
-                )
-            )
-
             if error is None and not self._retry_on_exhausted_stream:
                 _logger.info(
                     "%s: connection closed, stream exhausted", self._stream_name
                 )
                 await self._channel.close()
                 break
+
+            interval = self._retry_strategy.next_interval()
             error_str = f"Error: {error}" if error else "Stream exhausted"
             if interval is None:
                 _logger.error(
@@ -220,4 +215,6 @@ class GrpcStreamBroadcaster(Generic[InputT, OutputT]):
                 interval,
                 error_str,
             )
+
+            await sender.send(StreamRetrying(timedelta(seconds=interval), error))
             await asyncio.sleep(interval)

--- a/src/frequenz/client/base/streaming.py
+++ b/src/frequenz/client/base/streaming.py
@@ -188,7 +188,9 @@ class GrpcStreamBroadcaster(Generic[InputT, OutputT]):
 
             await sender.send(
                 StreamStopped(
-                    retry_time=timedelta(seconds=interval) if interval else None,
+                    retry_time=(
+                        timedelta(seconds=interval) if interval is not None else None
+                    ),
                     exception=error,
                 )
             )

--- a/src/frequenz/client/base/streaming.py
+++ b/src/frequenz/client/base/streaming.py
@@ -27,12 +27,12 @@ OutputT = TypeVar("OutputT")
 
 
 @dataclass(frozen=True, kw_only=True)
-class StreamStartedEvent:
+class StreamStarted:
     """Event indicating that the stream has started."""
 
 
 @dataclass(frozen=True, kw_only=True)
-class StreamStoppedEvent:
+class StreamStopped:
     """Event indicating that the stream has stopped."""
 
     retry_time: timedelta | None = None
@@ -42,7 +42,7 @@ class StreamStoppedEvent:
     """The exception that caused the stream to stop, if any."""
 
 
-StreamEvent: TypeAlias = StreamStartedEvent | StreamStoppedEvent
+StreamEvent: TypeAlias = StreamStarted | StreamStopped
 """Type alias for the events that can be sent over the stream."""
 
 
@@ -79,9 +79,9 @@ class GrpcStreamBroadcaster(Generic[InputT, OutputT]):
 
         for msg in recv:
             match msg:
-                case StreamStartedEvent():
+                case StreamStarted():
                     print("Stream started")
-                case StreamStoppedEvent() as event:
+                case StreamStopped() as event:
                     print(f"Stream stopped, reason {event.exception}, retry in {event.retry_time}")
                 case int() as output:
                     print(f"Received message: {output}")
@@ -168,7 +168,7 @@ class GrpcStreamBroadcaster(Generic[InputT, OutputT]):
             _logger.info("%s: starting to stream", self._stream_name)
             try:
                 call = self._stream_method()
-                await sender.send(StreamStartedEvent())
+                await sender.send(StreamStarted())
                 async for msg in call:
                     await sender.send(self._transform(msg))
             except grpc.aio.AioRpcError as err:
@@ -177,7 +177,7 @@ class GrpcStreamBroadcaster(Generic[InputT, OutputT]):
             interval = self._retry_strategy.next_interval()
 
             await sender.send(
-                StreamStoppedEvent(
+                StreamStopped(
                     retry_time=timedelta(seconds=interval) if interval else None,
                     exception=error,
                 )

--- a/src/frequenz/client/base/streaming.py
+++ b/src/frequenz/client/base/streaming.py
@@ -42,7 +42,15 @@ class StreamStopped:
     """The exception that caused the stream to stop, if any."""
 
 
-StreamEvent: TypeAlias = StreamStarted | StreamStopped
+@dataclass(frozen=True)
+class StreamFatalError:
+    """Event indicating that the stream has stopped due to an unrecoverable error."""
+
+    exception: Exception
+    """The exception that caused the stream to stop."""
+
+
+StreamEvent: TypeAlias = StreamStarted | StreamStopped | StreamFatalError
 """Type alias for the events that can be sent over the stream."""
 
 
@@ -83,6 +91,8 @@ class GrpcStreamBroadcaster(Generic[InputT, OutputT]):
                     print("Stream started")
                 case StreamStopped(delay, error):
                     print(f"Stream stopped, reason {error}, retry in {delay}")
+                case StreamFatalError(error):
+                    print(f"Stream will stop because of a fatal error: {error}")
                 case int() as output:
                     print(f"Received message: {output}")
         ```
@@ -197,6 +207,8 @@ class GrpcStreamBroadcaster(Generic[InputT, OutputT]):
                     self._retry_strategy.get_progress(),
                     error_str,
                 )
+                if error is not None:
+                    await sender.send(StreamFatalError(error))
                 await self._channel.close()
                 break
             _logger.warning(

--- a/src/frequenz/client/base/streaming.py
+++ b/src/frequenz/client/base/streaming.py
@@ -26,12 +26,12 @@ OutputT = TypeVar("OutputT")
 """The output type of the stream."""
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True)
 class StreamStarted:
     """Event indicating that the stream has started."""
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True)
 class StreamStopped:
     """Event indicating that the stream has stopped."""
 
@@ -81,8 +81,8 @@ class GrpcStreamBroadcaster(Generic[InputT, OutputT]):
             match msg:
                 case StreamStarted():
                     print("Stream started")
-                case StreamStopped() as event:
-                    print(f"Stream stopped, reason {event.exception}, retry in {event.retry_time}")
+                case StreamStopped(delay, error):
+                    print(f"Stream stopped, reason {error}, retry in {delay}")
                 case int() as output:
                     print(f"Received message: {output}")
         ```

--- a/src/frequenz/client/base/streaming.py
+++ b/src/frequenz/client/base/streaming.py
@@ -101,7 +101,7 @@ class GrpcStreamBroadcaster(Generic[InputT, OutputT]):
         Args:
             stream_name: A name to identify the stream in the logs.
             stream_method: A function that returns the grpc stream. This function is
-                called everytime the connection is lost and we want to retry.
+                called every time the connection is lost and we want to retry.
             transform: A function to transform the input type to the output type.
             retry_strategy: The retry strategy to use, when the connection is lost. Defaults
                 to retries every 3 seconds, with a jitter of 1 second, indefinitely.

--- a/tests/streaming/test_grpc_stream_broadcaster.py
+++ b/tests/streaming/test_grpc_stream_broadcaster.py
@@ -10,6 +10,7 @@ from contextlib import AsyncExitStack
 from datetime import timedelta
 from unittest import mock
 
+import grpc
 import grpc.aio
 import pytest
 from frequenz.channels import Receiver
@@ -44,12 +45,12 @@ def no_retry() -> mock.MagicMock:
     return mock_retry
 
 
-def mock_error() -> grpc.aio.AioRpcError:
+def make_error() -> grpc.aio.AioRpcError:
     """Mock error for testing."""
     return grpc.aio.AioRpcError(
-        code=mock.MagicMock(name="mock grpc code"),
-        initial_metadata=mock.MagicMock(),
-        trailing_metadata=mock.MagicMock(),
+        code=grpc.StatusCode.UNAVAILABLE,
+        initial_metadata=grpc.aio.Metadata(),
+        trailing_metadata=grpc.aio.Metadata(),
         details="mock details",
         debug_error_string="mock debug_error_string",
     )
@@ -222,7 +223,7 @@ async def test_streaming_error(  # pylint: disable=too-many-arguments
     """Test streaming errors."""
     caplog.set_level(logging.INFO)
 
-    error = mock_error()
+    error = make_error()
 
     helper = streaming.GrpcStreamBroadcaster(
         stream_name="test_helper",
@@ -269,7 +270,7 @@ async def test_retry_next_interval_zero(  # pylint: disable=too-many-arguments
 ) -> None:
     """Test retry logic when next_interval returns 0."""
     caplog.set_level(logging.WARNING)
-    error = mock_error()
+    error = make_error()
     mock_retry = mock.MagicMock(spec=retry.Strategy)
     mock_retry.next_interval.side_effect = [0, None]
     mock_retry.copy.return_value = mock_retry
@@ -311,17 +312,19 @@ async def test_messages_on_retry(
     receiver_ready_event: asyncio.Event,  # pylint: disable=redefined-outer-name
 ) -> None:
     """Test that messages are sent on retry."""
+    # We need to use a specific instance for all the test here because 2 errors created
+    # with the same arguments don't compare equal (grpc.aio.AioRpcError doesn't seem to
+    # provide a __eq__ method).
+    error = make_error()
+
     helper = streaming.GrpcStreamBroadcaster(
         stream_name="test_helper",
         stream_method=lambda: _ErroringAsyncIter(
-            mock_error(),
+            error,
             receiver_ready_event,
         ),
         transform=_transformer,
-        retry_strategy=retry.LinearBackoff(
-            limit=1,
-            interval=0.01,
-        ),
+        retry_strategy=retry.LinearBackoff(limit=1, interval=0.01, jitter=0.0),
         retry_on_exhausted_stream=True,
     )
 
@@ -335,15 +338,10 @@ async def test_messages_on_retry(
         items, events = await _split_message(receiver)
 
     assert items == []
-    assert [type(e) for e in events] == [
-        type(e)
-        for e in [
-            StreamStarted(),
-            StreamStopped(
-                exception=mock_error(), retry_time=timedelta(seconds=0.01)
-            ),
-            StreamStarted(),
-            StreamStopped(exception=mock_error(), retry_time=None),
-            StreamFatalError(mock_error()),
-        ]
+    assert events == [
+        StreamStarted(),
+        StreamStopped(timedelta(seconds=0.01), error),
+        StreamStarted(),
+        StreamStopped(None, error),
+        StreamFatalError(error),
     ]

--- a/tests/streaming/test_grpc_stream_broadcaster.py
+++ b/tests/streaming/test_grpc_stream_broadcaster.py
@@ -19,8 +19,8 @@ from frequenz.client.base import retry, streaming
 from frequenz.client.base.streaming import (
     StreamEvent,
     StreamFatalError,
+    StreamRetrying,
     StreamStarted,
-    StreamStopped,
 )
 
 
@@ -97,7 +97,7 @@ async def _split_message(
     events: list[StreamEvent] = []
     async for item in receiver:
         match item:
-            case StreamStarted() | StreamStopped() | StreamFatalError():
+            case StreamStarted() | StreamRetrying() | StreamFatalError():
                 events.append(item)
             case str():
                 items.append(item)
@@ -149,9 +149,7 @@ async def test_streaming_success_retry_on_exhausted(
         "transformed_3",
         "transformed_4",
     ]
-    assert events == [
-        StreamStopped(exception=None, retry_time=None),
-    ]
+    assert events == []
 
     assert caplog.record_tuples == [
         (
@@ -182,7 +180,7 @@ async def test_streaming_success(
         receiver_ready_event.set()
         items, events = await _split_message(receiver)
 
-    no_retry.next_interval.assert_called_once_with()
+    no_retry.next_interval.assert_not_called()
 
     assert items == [
         "transformed_0",
@@ -191,9 +189,7 @@ async def test_streaming_success(
         "transformed_3",
         "transformed_4",
     ]
-    assert events == [
-        StreamStopped(exception=None, retry_time=None),
-    ]
+    assert events == []
     assert caplog.record_tuples == [
         (
             "frequenz.client.base.streaming",
@@ -344,8 +340,7 @@ async def test_messages_on_retry(
     ]
     assert events == [
         StreamStarted(),
-        StreamStopped(timedelta(seconds=0.0), error),
+        StreamRetrying(timedelta(seconds=0.0), error),
         StreamStarted(),
-        StreamStopped(None, error),
         StreamFatalError(error),
     ]

--- a/tests/streaming/test_grpc_stream_broadcaster.py
+++ b/tests/streaming/test_grpc_stream_broadcaster.py
@@ -17,8 +17,8 @@ from frequenz.channels import Receiver
 from frequenz.client.base import retry, streaming
 from frequenz.client.base.streaming import (
     StreamEvent,
-    StreamStartedEvent,
-    StreamStoppedEvent,
+    StreamStarted,
+    StreamStopped,
 )
 
 
@@ -95,7 +95,7 @@ async def _split_message(
     events: list[StreamEvent] = []
     async for item in receiver:
         match item:
-            case StreamStartedEvent() | StreamStoppedEvent() as item:
+            case StreamStarted() | StreamStopped() as item:
                 events.append(item)
             case str():
                 items.append(item)
@@ -148,7 +148,7 @@ async def test_streaming_success_retry_on_exhausted(
         "transformed_4",
     ]
     assert events == [
-        StreamStoppedEvent(exception=None, retry_time=None),
+        StreamStopped(exception=None, retry_time=None),
     ]
 
     assert caplog.record_tuples == [
@@ -190,7 +190,7 @@ async def test_streaming_success(
         "transformed_4",
     ]
     assert events == [
-        StreamStoppedEvent(exception=None, retry_time=None),
+        StreamStopped(exception=None, retry_time=None),
     ]
     assert caplog.record_tuples == [
         (
@@ -337,11 +337,11 @@ async def test_messages_on_retry(
     assert [type(e) for e in events] == [
         type(e)
         for e in [
-            StreamStartedEvent(),
-            StreamStoppedEvent(
+            StreamStarted(),
+            StreamStopped(
                 exception=mock_error(), retry_time=timedelta(seconds=0.01)
             ),
-            StreamStartedEvent(),
-            StreamStoppedEvent(exception=mock_error(), retry_time=None),
+            StreamStarted(),
+            StreamStopped(exception=mock_error(), retry_time=None),
         ]
     ]

--- a/tests/streaming/test_grpc_stream_broadcaster.py
+++ b/tests/streaming/test_grpc_stream_broadcaster.py
@@ -320,8 +320,7 @@ async def test_messages_on_retry(
     helper = streaming.GrpcStreamBroadcaster(
         stream_name="test_helper",
         stream_method=lambda: _ErroringAsyncIter(
-            error,
-            receiver_ready_event,
+            error, receiver_ready_event, num_successes=2
         ),
         transform=_transformer,
         retry_strategy=retry.LinearBackoff(limit=1, interval=0.0, jitter=0.0),
@@ -337,7 +336,12 @@ async def test_messages_on_retry(
         receiver_ready_event.set()
         items, events = await _split_message(receiver)
 
-    assert items == []
+    assert items == [
+        "transformed_0",
+        "transformed_1",
+        "transformed_0",
+        "transformed_1",
+    ]
     assert events == [
         StreamStarted(),
         StreamStopped(timedelta(seconds=0.0), error),

--- a/tests/streaming/test_grpc_stream_broadcaster.py
+++ b/tests/streaming/test_grpc_stream_broadcaster.py
@@ -17,6 +17,7 @@ from frequenz.channels import Receiver
 from frequenz.client.base import retry, streaming
 from frequenz.client.base.streaming import (
     StreamEvent,
+    StreamFatalError,
     StreamStarted,
     StreamStopped,
 )
@@ -95,7 +96,7 @@ async def _split_message(
     events: list[StreamEvent] = []
     async for item in receiver:
         match item:
-            case StreamStarted() | StreamStopped() as item:
+            case StreamStarted() | StreamStopped() | StreamFatalError():
                 events.append(item)
             case str():
                 items.append(item)
@@ -343,5 +344,6 @@ async def test_messages_on_retry(
             ),
             StreamStarted(),
             StreamStopped(exception=mock_error(), retry_time=None),
+            StreamFatalError(mock_error()),
         ]
     ]

--- a/tests/streaming/test_grpc_stream_broadcaster.py
+++ b/tests/streaming/test_grpc_stream_broadcaster.py
@@ -324,7 +324,7 @@ async def test_messages_on_retry(
             receiver_ready_event,
         ),
         transform=_transformer,
-        retry_strategy=retry.LinearBackoff(limit=1, interval=0.01, jitter=0.0),
+        retry_strategy=retry.LinearBackoff(limit=1, interval=0.0, jitter=0.0),
         retry_on_exhausted_stream=True,
     )
 
@@ -340,7 +340,7 @@ async def test_messages_on_retry(
     assert items == []
     assert events == [
         StreamStarted(),
-        StreamStopped(timedelta(seconds=0.01), error),
+        StreamStopped(timedelta(seconds=0.0), error),
         StreamStarted(),
         StreamStopped(None, error),
         StreamFatalError(error),


### PR DESCRIPTION
This PR contains several improvements to streamer events:

- **Remove `Event` suffix from stream events** (for shorter names)
- **Make stream event dataclasses not keyword-only** (for more compact pattern matching)
- **Add a `StreamFatalError` event** (for errors when the stream stops for good and can't be retried)
- **Replace `StreamStopped` with `StreamRetrying`** (only sent when the stream is retrying, not when it stops for good)

It also includes some minor improvements and fixes:

- **Send some valid messages in `test_messages_on_retry`**
- **Lower the retry interval to 0.0 in tests**
- **Do a proper full comparison for events in tests**
- **Fix example indentation and blank line**
- **Fix typo**
- **Improve release notes formatting**
