### PR TITLE
Make parameters named of new_receiver

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,11 +12,17 @@
     If calling this function manually and passing `ChannelOptions`, it is recommended
     to switch to passing `ChannelOptions` via keyword argument.
 
+* All parameters of the Streamers `new_receiver` method are now keyword-only arguments. This means that you must specify them by name when calling the method, e.g.:
+
+    ```python
+    recv = streamer.new_receiver(max_size=50, warn_on_overflow=True)
+    ```
+
 ## New Features
 
 * The streaming client, when using `new_receiver(include_events=True)`, will now return a receiver that yields stream notification events, such as `StreamStarted`, `StreamRetrying`, and `StreamFatalError`. This allows you to monitor the state of the stream:
 
-    ```python
+    ```python
     recv = streamer.new_receiver(include_events=True)
 
     for msg in recv:

--- a/src/frequenz/client/base/streaming.py
+++ b/src/frequenz/client/base/streaming.py
@@ -194,26 +194,26 @@ class GrpcStreamBroadcaster(Generic[InputT, OutputT]):
     @overload
     def new_receiver(
         self,
+        *,
         maxsize: int = 50,
         warn_on_overflow: bool = True,
-        *,
         include_events: Literal[False] = False,
     ) -> channels.Receiver[OutputT]: ...
 
     @overload
     def new_receiver(
         self,
+        *,
         maxsize: int = 50,
         warn_on_overflow: bool = True,
-        *,
         include_events: Literal[True],
     ) -> channels.Receiver[StreamEvent | OutputT]: ...
 
     def new_receiver(
         self,
+        *,
         maxsize: int = 50,
         warn_on_overflow: bool = True,
-        *,
         include_events: bool = False,
     ) -> channels.Receiver[OutputT] | channels.Receiver[StreamEvent | OutputT]:
         """Create a new receiver for the stream.


### PR DESCRIPTION
- **Make all parameters of streamers `new_receiver` named**

https://github.com/frequenz-floss/frequenz-client-base-python/pull/154#discussion_r2126471087
