### PR TITLE
Add Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/auto-dependabot.yaml
+++ b/.github/workflows/auto-dependabot.yaml
@@ -1,0 +1,19 @@
+name: Auto-merge Dependabot PRs
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto-merge Dependabot PR
+        uses: frequenz-floss/dependabot-auto-approve@3cad5f42e79296505473325ac6636be897c8b8a1 # v1.3.2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          merge-method: 'merge'

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,6 @@
 # Each line is a file pattern followed by one or more owners.
 # Owners will be requested for review when someone opens a pull request.
 
-# Fallback owner.
-# These are the default owners for everything in the repo, unless a later match
-# takes precedence.
-* @frequenz-floss/python-sdk-team
+# Only apply to source code directories to allow dependabot PRs that only
+# modify pyproject.toml to be auto-merged without requiring code owner approval.
+/{src,tests,docs,dist}/ @frequenz-floss/python-sdk-team


### PR DESCRIPTION
## Summary
- Add GitHub workflow to automatically approve and merge Dependabot PRs
- Uses `merge` method for clean commit history